### PR TITLE
feat: add plugin system

### DIFF
--- a/src/Config/StatimateConfig.php
+++ b/src/Config/StatimateConfig.php
@@ -9,6 +9,7 @@ use Headercat\Statimate\Compiler\CompileTarget;
 use Headercat\Statimate\Compiler\Preset\BladeCompiler;
 use Headercat\Statimate\Compiler\Preset\MarkdownCompiler;
 use Headercat\Statimate\Helper\Pagination;
+use Headercat\Statimate\Plugin\PluginInterface;
 use InvalidArgumentException;
 use ReflectionFunction;
 use RuntimeException;
@@ -36,6 +37,11 @@ final class StatimateConfig
      * @var array<string, Closure> Document compilers.
      */
     private(set) array $documentCompilers = [];
+
+    /**
+     * @var list<class-string<PluginInterface>> Registered plugin class names.
+     */
+    private(set) array $registeredPlugins = [];
 
     /**
      * Constructor.
@@ -166,6 +172,25 @@ final class StatimateConfig
 
         $extension = '.' . ltrim(strtolower($extension), '.');
         $this->documentCompilers[$extension] = $compiler;
+        return $this;
+    }
+
+    /**
+     * Add plugin.
+     *
+     * @param class-string<PluginInterface> $pluginClass Class name of the plugin.
+     *
+     * @return self
+     */
+    public function addPlugin(string $pluginClass): self
+    {
+        if (in_array($pluginClass, $this->registeredPlugins)) {
+            throw new UnexpectedValueException(sprintf(
+                'Argument #1 $pluginClass must be registered once, but given "%s" already registered.',
+                $pluginClass,
+            ));
+        }
+        new $pluginClass()->register($this);
         return $this;
     }
 

--- a/src/Plugin/PluginInterface.php
+++ b/src/Plugin/PluginInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Headercat\Statimate\Plugin;
+
+use Headercat\Statimate\Config\StatimateConfig;
+
+interface PluginInterface
+{
+    /**
+     * Register the plugin.
+     *
+     * @param StatimateConfig $config
+     *
+     * @return void
+     */
+    public function register(StatimateConfig $config): void;
+}

--- a/src/Plugin/Preset/BladePlugin/BladeCompiler.php
+++ b/src/Plugin/Preset/BladePlugin/BladeCompiler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Headercat\Statimate\Compiler\Preset;
+namespace Headercat\Statimate\Plugin\Preset\BladePlugin;
 
 use Closure;
 use Headercat\Statimate\Compiler\CompileTarget;

--- a/src/Plugin/Preset/BladePlugin/BladePlugin.php
+++ b/src/Plugin/Preset/BladePlugin/BladePlugin.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Headercat\Statimate\Plugin\Preset\BladePlugin;
+
+use Headercat\Statimate\Config\StatimateConfig;
+use Headercat\Statimate\Plugin\PluginInterface;
+
+final class BladePlugin implements PluginInterface
+{
+    public function register(StatimateConfig $config): void
+    {
+        $config->addDocumentCompiler('.blade.php', BladeCompiler::compileDocument(...));
+    }
+}

--- a/src/Plugin/Preset/MarkdownPlugin/MarkdownCompiler.php
+++ b/src/Plugin/Preset/MarkdownPlugin/MarkdownCompiler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Headercat\Statimate\Compiler\Preset;
+namespace Headercat\Statimate\Plugin\Preset\MarkdownPlugin;
 
 use Headercat\Statimate\Compiler\CompileTarget;
 use League\CommonMark\CommonMarkConverter;

--- a/src/Plugin/Preset/MarkdownPlugin/MarkdownPlugin.php
+++ b/src/Plugin/Preset/MarkdownPlugin/MarkdownPlugin.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Headercat\Statimate\Plugin\Preset\MarkdownPlugin;
+
+use Headercat\Statimate\Config\StatimateConfig;
+use Headercat\Statimate\Plugin\PluginInterface;
+
+final class MarkdownPlugin implements PluginInterface
+{
+    public function register(StatimateConfig $config): void
+    {
+        $config->addDocumentCompiler('.md', MarkdownCompiler::compileDocument(...));
+    }
+}

--- a/src/Plugin/Preset/PaginationPlugin/Pagination.php
+++ b/src/Plugin/Preset/PaginationPlugin/Pagination.php
@@ -2,18 +2,21 @@
 
 declare(strict_types=1);
 
-namespace Headercat\Statimate\Helper;
+namespace Headercat\Statimate\Plugin\Preset\PaginationPlugin;
 
 use Closure;
 use Headercat\Statimate\Config\StatimateConfig;
 use Headercat\Statimate\Router\Route;
 use Headercat\Statimate\Router\RouteCollector;
+use RuntimeException;
 use UnexpectedValueException;
 
 final class Pagination
 {
     /**
      * @var StatimateConfig Statimate configuration.
+     * @noinspection PhpPropertyOnlyWrittenInspection
+     * @phpstan-ignore-next-line
      */
     private static StatimateConfig $config;
 
@@ -26,18 +29,6 @@ final class Pagination
      * @var array<string, list<list<Route>>> Map of the pagination key and its document routes.
      */
     private static array $keyRoutes = [];
-
-    /**
-     * Initialize the pagination helper.
-     *
-     * @param StatimateConfig $config Statimate configuration.
-     *
-     * @return void
-     */
-    public static function init(StatimateConfig $config): void
-    {
-        self::$config = $config;
-    }
 
     /**
      * Get the pagination param function.
@@ -68,7 +59,7 @@ final class Pagination
      */
     public static function getPageDocumentRoutes(string $key, string|int $page): array
     {
-        $page = max((int) $page, 1);
+        $page = max((int)$page, 1);
         return (self::$keyRoutes[$key] ?? [])[$page - 1] ?? [];
     }
 
@@ -100,6 +91,12 @@ final class Pagination
             ));
         }
         if (!isset(self::$routes)) {
+            if (!isset(self::$config)) {
+                throw new RuntimeException(
+                    'PaginationPlugin has not been registered.'
+                    . ' Add it using StatimateConfig::addPlugin() first.'
+                );
+            }
             self::$routes = new RouteCollector(self::$config)
                 ->collect(self::$config->routeDir, true);
         }

--- a/src/Plugin/Preset/PaginationPlugin/PaginationPlugin.php
+++ b/src/Plugin/Preset/PaginationPlugin/PaginationPlugin.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Headercat\Statimate\Plugin\Preset\PaginationPlugin;
+
+use Headercat\Statimate\Config\StatimateConfig;
+use Headercat\Statimate\Plugin\PluginInterface;
+
+final class PaginationPlugin implements PluginInterface
+{
+    public function register(StatimateConfig $config): void
+    {
+        // I know it's stupid code, but...
+        // I just don't want the user's IDE to autocomplete any methods or properties that can access to P::$config.
+
+        $setter = function () use ($config) {
+            self::$config = $config; // @phpstan-ignore-line
+        };
+        $setter = $setter->bindTo(new Pagination(), Pagination::class);
+        $setter();
+    }
+}


### PR DESCRIPTION
This pull request refactors the plugin architecture in the `Statimate` project, transitioning from direct compiler and helper initialization to a plugin-based system. It introduces a `PluginInterface` and corresponding plugins for Blade, Markdown, and Pagination. The changes improve modularity, simplify configuration, and ensure plugins are registered explicitly.

### Plugin System Refactor:
* Introduced `PluginInterface` to define a standard for plugins, requiring a `register` method to integrate with `StatimateConfig` (`src/Plugin/PluginInterface.php`).
* Added `addPlugin` method in `StatimateConfig` to register plugins, ensuring no duplicate registrations and initializing plugins during configuration setup (`src/Config/StatimateConfig.php`) [[1]](diffhunk://#diff-f6269abd79a5ed1b13efca7985c38f8111167838d102898cfbf3fecc8a371335R41-L61) [[2]](diffhunk://#diff-f6269abd79a5ed1b13efca7985c38f8111167838d102898cfbf3fecc8a371335R185-R203).

### Plugin Implementations:
* Created `BladePlugin`, `MarkdownPlugin`, and `PaginationPlugin`, each implementing `PluginInterface` and encapsulating their respective functionality (`src/Plugin/Preset/BladePlugin/BladePlugin.php`, `src/Plugin/Preset/MarkdownPlugin/MarkdownPlugin.php`, `src/Plugin/Preset/PaginationPlugin/PaginationPlugin.php`) [[1]](diffhunk://#diff-88c773a91714ee0d6cd24855e8acfa0555b6c71d5120bad5b9704a21c8e05e01R1-R16) [[2]](diffhunk://#diff-1b49503d383c98d42d4386ce7152f3f238a17fdb122169d69d04cd5e34d910c5R1-R16) [[3]](diffhunk://#diff-197566b2cfe072e2e57eba7fd54bdea06af713f6f18f6438ebae2f7edde96c9dR1-R23).
* Moved existing compiler and helper logic to their respective plugin namespaces (`BladeCompiler`, `MarkdownCompiler`, and `Pagination` files renamed and updated) [[1]](diffhunk://#diff-16e5bef5c3fd5272404f4594c968cf68e00d10c77d9773ee871e181e920b9f20L5-R5) [[2]](diffhunk://#diff-fc1f735a78763c962a038bcfc0d6902d754482d7a02fb7136efdbe62748f3991L5-R5) [[3]](diffhunk://#diff-098dc538a365acc5beeb87ba0b0b3d902bf3064977fea7ff5be2b505e2cb4d33L5-R19).

### Pagination Enhancements:
* Removed the static `init` method from `Pagination` and replaced it with plugin registration, throwing a runtime exception if the plugin is not registered (`src/Plugin/Preset/PaginationPlugin/Pagination.php`) [[1]](diffhunk://#diff-098dc538a365acc5beeb87ba0b0b3d902bf3064977fea7ff5be2b505e2cb4d33L30-L41) [[2]](diffhunk://#diff-098dc538a365acc5beeb87ba0b0b3d902bf3064977fea7ff5be2b505e2cb4d33R94-R99).