### PR TITLE
feat: add init command to console application

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,7 @@
         "league/commonmark": "^2.6",
         "symfony/console": "^7.2",
         "mnapoli/silly": "^1.9",
-        "workerman/workerman": "^5.1",
-        "ext-pthreads": "*"
+        "workerman/workerman": "^5.1"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1"


### PR DESCRIPTION
This pull request introduces a new `init` command to the Statimate console application, refines dependency management, and makes minor formatting adjustments. The most significant changes include adding the `initCommand` method to initialize a new Statimate project, updating dependencies in `composer.json`, and improving code formatting for consistency.

### New Feature: `init` Command
* Added a new `initCommand` method to the `Application` class in `src/Console/Application.php`. This command initializes a new Statimate project by creating essential project files (`composer.json`, `statimate.config.php`, and route templates), verifying the directory is empty, and installing dependencies.
* Registered the `init` command in the `Application` constructor with a description.

### Dependency Management
* Removed the `ext-pthreads` dependency from `composer.json`, as it is no longer required.

### Code Formatting
* Standardized trailing commas in array definitions for improved consistency in the `serveCommand` method.