### PR TITLE
ci: remove version property from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "headercat/statimate",
     "description": "Static site generator for minimalist.",
-    "version": "0.0.1",
     "license": "MIT",
     "authors": [
         {

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -26,12 +26,14 @@ use Workerman\Protocols\Http\ServerSentEvents;
 
 final class Application extends \Silly\Application
 {
+    private const string VERSION = '0.0.2';
+
     /**
      * Constructor.
      */
     public function __construct()
     {
-        parent::__construct('☀ statimate.', $this->getVersionFromComposer());
+        parent::__construct('☀ statimate.', self::VERSION);
         $this->useContainer(Container::getInstance());
 
         $this->command('init', $this->initCommand(...))
@@ -360,25 +362,6 @@ HTML)) {
         Output::write('');
 
         Worker::runAll();
-    }
-
-    /**
-     * Get a version string from composer.json.
-     *
-     * @return string
-     */
-    private function getVersionFromComposer(): string
-    {
-        if (file_exists($composerJsonPath = __DIR__ . '/../../composer.json')) {
-            $composerData = json_decode(file_get_contents($composerJsonPath) ?: '{}');
-            assert(is_object($composerData));
-            if (property_exists($composerData, 'version')) {
-                $version = $composerData->version;
-                assert(is_string($version));
-                return $version;
-            }
-        }
-        return '0.0.1';
     }
 
     /**


### PR DESCRIPTION
This pull request refactors the way the application version is handled by introducing a constant for the version and removing the dynamic version retrieval from `composer.json`. It simplifies the code and improves performance by avoiding file I/O during runtime.

### Version handling refactor:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L4): Removed the `version` field, as the version is now managed directly in the codebase.
* [`src/Console/Application.php`](diffhunk://#diff-c3161949b1e6a9be81ac8e805ddd3d9f9a8da07e10e3932c297dfadf1ea47da7R29-R36): Added a `VERSION` constant (`0.0.2`) to the `Application` class and updated the constructor to use this constant instead of dynamically retrieving the version from `composer.json`.
* [`src/Console/Application.php`](diffhunk://#diff-c3161949b1e6a9be81ac8e805ddd3d9f9a8da07e10e3932c297dfadf1ea47da7L365-L383): Removed the `getVersionFromComposer` method, as it is no longer needed with the introduction of the `VERSION` constant.