### PR TITLE
fix: change to target proper statimate binary path

### DIFF
--- a/.github/workflows/official-website.yml
+++ b/.github/workflows/official-website.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Dependencies
         run: composer install
       - name: Build Statimate Project
-        run: cd docs && ../vendor/bin/statimate build
+        run: cd docs && ../bin/statimate build
       - name: Upload Artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
This pull request updates the build process in the GitHub Actions workflow for the official website. The most notable change involves modifying the path to the `statimate` binary.

Build process update:

* [`.github/workflows/official-website.yml`](diffhunk://#diff-fb45b00f034c26d9e30b8adc063adcb9197c2693db57fa58e4b4c4013460ce46L32-R32): Changed the path to the `statimate` binary from `../vendor/bin/statimate` to `../bin/statimate` in the "Build Statimate Project" step.