### PR TITLE
feat: add hook system

### DIFF
--- a/src/Compiler/CompileTarget.php
+++ b/src/Compiler/CompileTarget.php
@@ -7,9 +7,9 @@ namespace Headercat\Statimate\Compiler;
 use Headercat\Statimate\Config\StatimateConfig;
 use UnexpectedValueException;
 
-final readonly class CompileTarget
+final class CompileTarget
 {
-    private(set) string $content;
+    public string $content;
 
     /**
      * Constructor.
@@ -19,9 +19,9 @@ final readonly class CompileTarget
      * @param StatimateConfig      $config Statimate configuration.
      */
     public function __construct(
-        private(set) string $path,
-        private(set) array $vars,
-        private(set) StatimateConfig $config,
+        public string          $path,
+        public array           $vars,
+        public StatimateConfig $config,
     )
     {
         try {

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Headercat\Statimate\Compiler;
 
+use Headercat\Statimate\Compiler\Hooks\AfterCompileHook;
+use Headercat\Statimate\Compiler\Hooks\BeforeCompileHook;
 use Headercat\Statimate\Config\StatimateConfig;
 use Headercat\Statimate\Router\Route;
 use RuntimeException;
@@ -87,6 +89,7 @@ final readonly class Compiler
             if (!str_ends_with($path, $ext)) {
                 continue;
             }
+            $compileTarget = BeforeCompileHook::dispatch($compileTarget);
             $output = $handler($compileTarget);
             if (!is_string($output)) {
                 throw new RuntimeException(sprintf(
@@ -95,8 +98,8 @@ final readonly class Compiler
                     get_debug_type($output),
                 ));
             }
-            return $output;
+            return AfterCompileHook::dispatch($output);
         }
-        return $compileTarget->content;
+        return AfterCompileHook::dispatch($compileTarget->content);
     }
 }

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -41,6 +41,7 @@ final readonly class Compiler
         $content = '';
         foreach ($this->getCompileTargetPaths($route) as $path) {
             $content = $this->getCompiledContent($path, [
+                'route' => $route,
                 'params' => $route->parameters,
                 'content' => $content,
             ]);

--- a/src/Compiler/Hooks/AfterCompileHook.php
+++ b/src/Compiler/Hooks/AfterCompileHook.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Headercat\Statimate\Compiler\Hooks;
+
+use Closure;
+use Headercat\Statimate\Hook\AbstractHook;
+
+/**
+ * @extends AbstractHook<string, string>
+ */
+final class AfterCompileHook extends AbstractHook
+{
+    /**
+     * Subscribe the hook.
+     *
+     * @param Closure(string $compiledContent):string $subscriber Compiled content as an input and manipulated content
+     *                                                as an output.
+     *
+     * @return string Identifier of the subscriber.
+     */
+    public static function subscribe(Closure $subscriber): string
+    {
+        return parent::subscribe($subscriber);
+    }
+}

--- a/src/Compiler/Hooks/BeforeCompileHook.php
+++ b/src/Compiler/Hooks/BeforeCompileHook.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Headercat\Statimate\Compiler\Hooks;
+
+use Closure;
+use Headercat\Statimate\Compiler\CompileTarget;
+use Headercat\Statimate\Hook\AbstractHook;
+
+/**
+ * @extends AbstractHook<CompileTarget, CompileTarget>
+ */
+final class BeforeCompileHook extends AbstractHook
+{
+    /**
+     * Subscribe the hook.
+     *
+     * @param Closure(CompileTarget $route):CompileTarget $subscriber Compile-target as an input and manipulated
+     *                                                    compile-target as an output.
+     *
+     * @return string
+     */
+    public static function subscribe(Closure $subscriber): string
+    {
+        return parent::subscribe($subscriber);
+    }
+}

--- a/src/Config/StatimateConfig.php
+++ b/src/Config/StatimateConfig.php
@@ -8,6 +8,7 @@ use Closure;
 use Headercat\Statimate\Compiler\CompileTarget;
 use Headercat\Statimate\Plugin\PluginInterface;
 use Headercat\Statimate\Plugin\Preset\BladePlugin\BladePlugin;
+use Headercat\Statimate\Plugin\Preset\FrontMatterPlugin\FrontMatterPlugin;
 use Headercat\Statimate\Plugin\Preset\MarkdownPlugin\MarkdownPlugin;
 use Headercat\Statimate\Plugin\Preset\PaginationPlugin\PaginationPlugin;
 use InvalidArgumentException;
@@ -50,6 +51,7 @@ final class StatimateConfig
         BladePlugin::class,
         MarkdownPlugin::class,
         PaginationPlugin::class,
+        FrontMatterPlugin::class,
     ];
 
     /**

--- a/src/Hook/AbstractHook.php
+++ b/src/Hook/AbstractHook.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Headercat\Statimate\Hook;
+
+use Closure;
+use LogicException;
+
+/**
+ * @template TInput
+ * @template TOutput
+ */
+abstract class AbstractHook
+{
+    /**
+     * @var array<string, array<string, Closure>> Map of the hook name and its listeners.
+     */
+    private static array $subscribers = [];
+
+    /**
+     * Subscribe the hook.
+     *
+     * @param Closure(TInput):TOutput $subscriber
+     *
+     * @return string Identifier of the subscriber.
+     */
+    public static function subscribe(Closure $subscriber): string
+    {
+        if (static::class === self::class) {
+            throw new LogicException('Cannot subscribe to the abstract class "' . static::class . '".');
+        }
+        if (!array_key_exists(static::class, self::$subscribers)) {
+            self::$subscribers[static::class] = [];
+        }
+
+        $name = spl_object_hash($subscriber);
+        self::$subscribers[static::class][$name] = $subscriber;
+        return $name;
+    }
+
+    /**
+     * Dispatch the event.
+     *
+     * @param TInput $data Data to dispatch.
+     *
+     * @return TOutput
+     */
+    public static function dispatch(mixed $data): mixed
+    {
+        $data = is_object($data) ? clone $data : $data;
+        foreach (self::$subscribers[static::class] ?? [] as $subscriber) {
+            $data = $subscriber($data);
+        }
+        return $data;
+    }
+}

--- a/src/Plugin/Preset/FrontMatterPlugin/FrontMatterPlugin.php
+++ b/src/Plugin/Preset/FrontMatterPlugin/FrontMatterPlugin.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Headercat\Statimate\Plugin\Preset\FrontMatterPlugin;
+
+use Headercat\Statimate\Compiler\CompileTarget;
+use Headercat\Statimate\Compiler\Hooks\AfterCompileHook;
+use Headercat\Statimate\Compiler\Hooks\BeforeCompileHook;
+use Headercat\Statimate\Config\StatimateConfig;
+use Headercat\Statimate\Plugin\PluginInterface;
+use Headercat\Statimate\Router\Hooks\AfterCollectRouteHook;
+
+final class FrontMatterPlugin implements PluginInterface
+{
+    private const string FRONT_MATTER_REGEX = '/^---\n(.*?)\n---\n/';
+    public function register(StatimateConfig $config): void
+    {
+        AfterCollectRouteHook::subscribe(function (array $routes) {
+            foreach ($routes as $route) {
+                $content = file_get_contents($route->sourcePath);
+                if (!$content) {
+                    continue;
+                }
+                $content = preg_replace(self::FRONT_MATTER_REGEX, '', $content, 1);
+                $route->extras['content'] = $content;
+            }
+            return $routes;
+        });
+
+        BeforeCompileHook::subscribe(function (CompileTarget $target) {
+            $output = preg_replace(self::FRONT_MATTER_REGEX, '', $target->content, 1);
+            assert(is_string($output));
+            $target->content = $output;
+            return $target;
+        });
+        AfterCompileHook::subscribe(function (string $compiledContent) {
+            $output = preg_replace(self::FRONT_MATTER_REGEX, '', $compiledContent, 1);
+            assert(is_string($output));
+            return $output;
+        });
+    }
+}

--- a/src/Router/Hooks/AfterCollectRouteHook.php
+++ b/src/Router/Hooks/AfterCollectRouteHook.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Headercat\Statimate\Router\Hooks;
+
+use Closure;
+use Headercat\Statimate\Hook\AbstractHook;
+use Headercat\Statimate\Router\Route;
+
+/**
+ * @extends AbstractHook<list<Route>, list<Route>>
+ */
+final class AfterCollectRouteHook extends AbstractHook
+{
+    /**
+     * Subscribe the hook.
+     *
+     * @param Closure(list<Route> $routes):list<Route> $subscriber List of routes as an input and manipulated list of
+     *                                                             routes as an output. Sorting is not guaranteed, but
+     *                                                             it's highly recommended to return sorted values.
+     *                                                             The final returned value must not have duplicate
+     *                                                             paths.
+     *
+     * @return string
+     */
+    public static function subscribe(Closure $subscriber): string
+    {
+        return parent::subscribe($subscriber);
+    }
+}

--- a/src/Router/Hooks/BeforeCollectRouteHook.php
+++ b/src/Router/Hooks/BeforeCollectRouteHook.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Headercat\Statimate\Router\Hooks;
+
+use Closure;
+use Headercat\Statimate\Hook\AbstractHook;
+
+/**
+ * @extends AbstractHook<string, string>
+ */
+final class BeforeCollectRouteHook extends AbstractHook
+{
+    /**
+     * Subscribe the hook.
+     *
+     * @param Closure(string $sourceDir):string $subscriber Source-dir as an input and manipulated source-path as an
+     *                                                      output. All source-dirs do not have any guarantee that is
+     *                                                      some of a real-existence path. But the final output
+     *                                                      source-dir should be a real-existence path, otherwise the
+     *                                                      build process will be failed.
+     *
+     * @return string
+     */
+    public static function subscribe(Closure $subscriber): string
+    {
+        return parent::subscribe($subscriber);
+    }
+}

--- a/src/Router/Route.php
+++ b/src/Router/Route.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Headercat\Statimate\Router;
 
-final readonly class Route
+final class Route
 {
     /**
      * Constructor.
@@ -13,12 +13,14 @@ final readonly class Route
      * @param string                $sourcePath
      * @param bool                  $isDocument
      * @param array<string, string> $parameters
+     * @param array<string, mixed>  $extras
      */
     public function __construct(
         public string $route,
         public string $sourcePath,
         public bool   $isDocument,
         public array  $parameters,
+        public array  $extras = [],
     )
     {
     }

--- a/src/Router/RouteCollector.php
+++ b/src/Router/RouteCollector.php
@@ -7,6 +7,8 @@ namespace Headercat\Statimate\Router;
 use Closure;
 use FilesystemIterator;
 use Headercat\Statimate\Config\StatimateConfig;
+use Headercat\Statimate\Router\Hooks\AfterCollectRouteHook;
+use Headercat\Statimate\Router\Hooks\BeforeCollectRouteHook;
 use LogicException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -51,6 +53,7 @@ final class RouteCollector
      */
     public function collect(string $sourceDir, bool $ignoreCircularDependency = false): array
     {
+        $sourceDir = BeforeCollectRouteHook::dispatch($sourceDir);
         $realSourceDir = realpath($sourceDir);
         if (!$realSourceDir) {
             throw new UnexpectedValueException(sprintf(
@@ -62,6 +65,7 @@ final class RouteCollector
         foreach ($this->scanDirectory($realSourceDir) as $file) {
             $routes = array_merge($routes, $this->createRoutes($realSourceDir, $file, $ignoreCircularDependency));
         }
+        $routes = AfterCollectRouteHook::dispatch($routes);
 
         $registeredRoutePaths = [];
         foreach ($routes as $route) {

--- a/src/Writer/Hooks/BeforeCopyHook.php
+++ b/src/Writer/Hooks/BeforeCopyHook.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Headercat\Statimate\Writer\Hooks;
+
+use Closure;
+use Headercat\Statimate\Hook\AbstractHook;
+
+/**
+ * @phpstan-type HookData array{ dest: string, from: string }
+ * @extends AbstractHook<HookData, HookData>
+ */
+final class BeforeCopyHook extends AbstractHook
+{
+    /**
+     * Subscribe the hook.
+     *
+     * @param Closure(HookData $data):HookData $subscriber Array of a destination-path and from-path as an input and
+     *                                                     its manipulation as an output.
+     *
+     * @return string
+     */
+    public static function subscribe(Closure $subscriber): string
+    {
+        return parent::subscribe($subscriber);
+    }
+}

--- a/src/Writer/Hooks/BeforeWriteHook.php
+++ b/src/Writer/Hooks/BeforeWriteHook.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Headercat\Statimate\Writer\Hooks;
+
+use Closure;
+use Headercat\Statimate\Hook\AbstractHook;
+
+/**
+ * @phpstan-type HookData array{ dest: string, content: string }
+ * @extends AbstractHook<HookData, HookData>
+ */
+final class BeforeWriteHook extends AbstractHook
+{
+    /**
+     * Subscribe the hook.
+     *
+     * @param Closure(HookData $data):HookData $subscriber Array of a destination-path and the content as an input and
+     *                                                     its manipulation as an output.
+     *
+     * @return string
+     */
+    public static function subscribe(Closure $subscriber): string
+    {
+        return parent::subscribe($subscriber);
+    }
+}

--- a/src/Writer/Writer.php
+++ b/src/Writer/Writer.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Headercat\Statimate\Writer;
 
 use Headercat\Statimate\Config\StatimateConfig;
+use Headercat\Statimate\Writer\Hooks\BeforeCopyHook;
+use Headercat\Statimate\Writer\Hooks\BeforeWriteHook;
 use RuntimeException;
 
 final readonly class Writer
@@ -56,6 +58,8 @@ final readonly class Writer
     public function write(string $dest, string $content): void
     {
         $dest = $this->config->buildDir . $dest;
+        ['dest' => $dest, 'content' => $content] = BeforeWriteHook::dispatch(['dest' => $dest, 'content' => $content]);
+
         $this->createDirectory($dest);
         if (file_put_contents($dest, $content) === false) {
             throw new RuntimeException('Unable to write file "' . $dest . '".');
@@ -73,6 +77,8 @@ final readonly class Writer
     public function copy(string $dest, string $from): void
     {
         $dest = $this->config->buildDir . $dest;
+        ['dest' => $dest, 'from' => $from] = BeforeCopyHook::dispatch(['dest' => $dest, 'from' => $from]);
+
         $this->createDirectory($dest);
         if (!copy($from, $dest)) {
             throw new RuntimeException('Unable to copy file "' . $dest . '".');


### PR DESCRIPTION
This pull request introduces a hook system to allow dynamic customization during various stages of the compilation, routing, and writing processes. It also adds a new plugin (`FrontMatterPlugin`) and modifies the `CompileTarget` and `Route` classes to support enhanced flexibility. Below is a breakdown of the most significant changes:

### Hook System Implementation:
* Added an abstract class `AbstractHook` to manage hook subscriptions and dispatch events dynamically. (`src/Hook/AbstractHook.php`)
* Introduced new hooks:
  - `BeforeCompileHook` and `AfterCompileHook` for pre- and post-compilation customization. (`src/Compiler/Hooks/BeforeCompileHook.php`, `src/Compiler/Hooks/AfterCompileHook.php`) [[1]](diffhunk://#diff-28d8b479291d0bde915219cba6d650d5c6a1c127b17155135c5675362109b063R1-R28) [[2]](diffhunk://#diff-d3568b94aa1dcaaa9bd5442b0193140a20e72332b62bb52d24a91c71dbf40fd7R1-R27)
  - `BeforeCollectRouteHook` and `AfterCollectRouteHook` for route collection customization. (`src/Router/Hooks/BeforeCollectRouteHook.php`, `src/Router/Hooks/AfterCollectRouteHook.php`) [[1]](diffhunk://#diff-b23a1082dcbf4178aa4d54218c904b10e1c3d516d54aad42f9258c4e28db90c8R1-R30) [[2]](diffhunk://#diff-856c5d14aaed77a5fadb0ee7bfc4695854db993d870af23c494363fc4a1f3046R1-R31)
  - `BeforeWriteHook` and `BeforeCopyHook` for file writing and copying customization. (`src/Writer/Hooks/BeforeWriteHook.php`, `src/Writer/Hooks/BeforeCopyHook.php`) [[1]](diffhunk://#diff-759132c242f1d4a87d23635f6ffe2c32543af59d4adcd217867da0bf3e3b5a3eR1-R28) [[2]](diffhunk://#diff-a73822f5f83b428baa87288813aa5853a4ba845f7e5474b3daa4aa84ff72cd1aR1-R28)

### Plugin System Enhancement:
* Added the `FrontMatterPlugin` to strip front matter metadata from content during route collection, compilation, and post-compilation stages. (`src/Plugin/Preset/FrontMatterPlugin/FrontMatterPlugin.php`)
* Registered the `FrontMatterPlugin` in `StatimateConfig`. (`src/Config/StatimateConfig.php`) [[1]](diffhunk://#diff-f6269abd79a5ed1b13efca7985c38f8111167838d102898cfbf3fecc8a371335R11) [[2]](diffhunk://#diff-f6269abd79a5ed1b13efca7985c38f8111167838d102898cfbf3fecc8a371335R54)

### Compiler and Routing Updates:
* Updated `CompileTarget` and `Route` classes to remove `readonly` constraints and make properties `public`, enabling easier manipulation via hooks. (`src/Compiler/CompileTarget.php`, `src/Router/Route.php`) [[1]](diffhunk://#diff-53139d76337ef92d320b83521b7079be4bad6d2f5b542c012c28d63756057081L10-R12) [[2]](diffhunk://#diff-53139d76337ef92d320b83521b7079be4bad6d2f5b542c012c28d63756057081L22-R24) [[3]](diffhunk://#diff-79b8c10580a4cdc8816ff7094d84538c8f15af168dbc34b6274344d8df11ac86L7-R7) [[4]](diffhunk://#diff-79b8c10580a4cdc8816ff7094d84538c8f15af168dbc34b6274344d8df11ac86R16-R23)
* Enhanced `Compiler` and `RouteCollector` to integrate hooks for dynamic behavior during compilation and route collection. (`src/Compiler/Compiler.php`, `src/Router/RouteCollector.php`) [[1]](diffhunk://#diff-045bc10088b545333d85372d565b549da4db9e1e2bccd1394117d2846c80e936R44) [[2]](diffhunk://#diff-045bc10088b545333d85372d565b549da4db9e1e2bccd1394117d2846c80e936R93) [[3]](diffhunk://#diff-045bc10088b545333d85372d565b549da4db9e1e2bccd1394117d2846c80e936L98-R104) [[4]](diffhunk://#diff-98b9455878b50dc1e05f78f6a26c8a8889ac4f1a5f3b9b43b9069370e064e3c2R56) [[5]](diffhunk://#diff-98b9455878b50dc1e05f78f6a26c8a8889ac4f1a5f3b9b43b9069370e064e3c2R68)

### Writer Enhancements:
* Integrated `BeforeWriteHook` and `BeforeCopyHook` into the `Writer` class to allow pre-processing of file paths and content before writing or copying. (`src/Writer/Writer.php`) [[1]](diffhunk://#diff-e7481a92ff4be1f49bc5e7e1596acff4d62cdfc6e27ce8d8d42d1f8a76bb653dR61-R62) [[2]](diffhunk://#diff-e7481a92ff4be1f49bc5e7e1596acff4d62cdfc6e27ce8d8d42d1f8a76bb653dR80-R81)

These changes collectively enhance the flexibility and extensibility of the system, enabling developers to customize behaviors at key stages of the pipeline.