### PR TITLE
feat: add front-matter plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "league/commonmark": "^2.6",
         "symfony/console": "^7.2",
         "mnapoli/silly": "^1.9",
-        "workerman/workerman": "^5.1"
+        "workerman/workerman": "^5.1",
+        "symfony/yaml": "^7.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65b849d34548cc97caa50fe83d2f06db",
+    "content-hash": "64596460ae21e36a8854f596ab11ad6e",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -2764,6 +2764,78 @@
                 }
             ],
             "time": "2024-09-25T14:20:29+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v7.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "4c4b6f4cfcd7e52053f0c8bfad0f7f30fb924912"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/4c4b6f4cfcd7e52053f0c8bfad0f7f30fb924912",
+                "reference": "4c4b6f4cfcd7e52053f0c8bfad0f7f30fb924912",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-03T07:12:39+00:00"
         },
         {
             "name": "voku/portable-ascii",

--- a/docs/routes/#layout.blade.php
+++ b/docs/routes/#layout.blade.php
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
-    <title></title>
+    <title>{{ ($route->extras['title'] ?? null) ? ($route->extras['title'] . ' | statimate.') : 'statimate.' }}</title>
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300..700&display=swap" />

--- a/docs/routes/docs/creating-a-project.md
+++ b/docs/routes/docs/creating-a-project.md
@@ -1,3 +1,6 @@
+---
+title: Docs > Creating a Project
+---
 # Creating a Project
 
 If you haven't already installed statimate, run `composer global require headercat/statimate` to install.

--- a/docs/routes/docs/index.md
+++ b/docs/routes/docs/index.md
@@ -1,3 +1,6 @@
+---
+title: Docs > Introduction
+---
 # Introduction
 
 Statimate is a static site generator for minimalist. It aims to generate static sites with a modest level of tools 

--- a/src/Plugin/Preset/FrontMatterPlugin/FrontMatterPlugin.php
+++ b/src/Plugin/Preset/FrontMatterPlugin/FrontMatterPlugin.php
@@ -10,6 +10,7 @@ use Headercat\Statimate\Compiler\Hooks\BeforeCompileHook;
 use Headercat\Statimate\Config\StatimateConfig;
 use Headercat\Statimate\Plugin\PluginInterface;
 use Headercat\Statimate\Router\Hooks\AfterCollectRouteHook;
+use Symfony\Component\Yaml\Yaml;
 
 final class FrontMatterPlugin implements PluginInterface
 {
@@ -22,8 +23,10 @@ final class FrontMatterPlugin implements PluginInterface
                 if (!$content) {
                     continue;
                 }
-                $content = preg_replace(self::FRONT_MATTER_REGEX, '', $content, 1);
-                $route->extras['content'] = $content;
+                $content = preg_match(self::FRONT_MATTER_REGEX, $content, $matches) ? $matches[1] : '';
+                if (is_array($output = Yaml::parse($content))) {
+                    $route->extras = $output; // @phpstan-ignore-line
+                }
             }
             return $routes;
         });


### PR DESCRIPTION
This pull request introduces several changes to enhance functionality and improve the handling of YAML front matter in the `FrontMatterPlugin`. Key updates include adding support for parsing YAML front matter, updating dependencies, and improving the documentation layout.

### YAML Parsing and Plugin Enhancements:
* [`src/Plugin/Preset/FrontMatterPlugin/FrontMatterPlugin.php`](diffhunk://#diff-3e0ffd381d5afa707ee9f9b82218115b677124227832dbc1e05d44c76444d426R13): Added the `Yaml` component from Symfony to parse YAML front matter. Updated the `register` method to extract and parse YAML front matter, storing the parsed data in `$route->extras`. [[1]](diffhunk://#diff-3e0ffd381d5afa707ee9f9b82218115b677124227832dbc1e05d44c76444d426R13) [[2]](diffhunk://#diff-3e0ffd381d5afa707ee9f9b82218115b677124227832dbc1e05d44c76444d426L25-R29)

### Dependency Updates:
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L32-R33): Added `symfony/yaml` as a new dependency to enable YAML parsing.

### Documentation Improvements:
* [`docs/routes/#layout.blade.php`](diffhunk://#diff-49293efe8ceb38abaea0ea3fa1c3781ab14df54b1ce735b6c3fc5200b7384e9fL5-R5): Updated the `<title>` tag to dynamically display the route's title if available, improving the user experience.
* `docs/routes/docs/creating-a-project.md` and `docs/routes/docs/index.md`: Added YAML front matter to documentation files, which includes a `title` field for better organization and metadata handling. [[1]](diffhunk://#diff-eac61347630aeb355fcc22eabdf450790ead5598c7f68caf49632ed9eaf51fc5R1-R3) [[2]](diffhunk://#diff-6f12e4677a41ddd9091310277a4593c1fe32b7d692ff9853404d51337d1df650R1-R3)